### PR TITLE
Update Python tutorial links to all use Python 3

### DIFF
--- a/slides-en.html
+++ b/slides-en.html
@@ -477,7 +477,7 @@
         Why?<!-- .element: class="delayed" -->
 
         You changed <!-- .element: class="delayed" -->`y`, but the old value of `x` is still in memory.
-        Python will remember variable names until you close PyCharm or [clear them manually](https://docs.python.org/2/tutorial/datastructures.html#the-del-statement).
+        Python will remember variable names until you close PyCharm or [clear them manually](https://docs.python.org/3/tutorial/datastructures.html#the-del-statement).
       </script>
     </section>
 
@@ -1125,7 +1125,7 @@
         ufo_data_file.close()
         ```
 
-        More: https://docs.python.org/3.7/tutorial/inputoutput.html#reading-and-writing-files
+        More: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files
       </script>
     </section>
 
@@ -1416,7 +1416,7 @@
 
         ### Tutorials/Courses:
 
-        * [The (Official) Python Tutorial](http://docs.python.org/2.7/tutorial/)
+        * [The (Official) Python Tutorial](http://docs.python.org/3/tutorial/)
         * [Full Stack Python](http://www.fullstackpython.com)
         * [Udacity - Learn Object Oriented Python](http://www.udacity.com/course/programming-foundations-with-python--ud036)
 

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -465,7 +465,7 @@
         Pourquoi?<!-- .element: class="delayed" -->
 
         Vous avez modifié <!-- .element: class="delayed" -->`y`, mais l'ancienne valeur de `x` reste dans la mémoire.
-        Le Python se souvient des noms de variable jusqu'à ce que vous fermieze PyCharm ou [les effaciez manuellement](https://docs.python.org/2/tutorial/datastructures.html#the-del-statement).
+        Le Python se souvient des noms de variable jusqu'à ce que vous fermieze PyCharm ou [les effaciez manuellement](https://docs.python.org/3/tutorial/datastructures.html#the-del-statement).
       </script>
     </section>
 
@@ -1403,7 +1403,7 @@
 
         ### Tutoriels / cours :
 
-        * [Tutoriel Python officiel](http://docs.python.org/2.7/tutorial/)
+        * [Tutoriel Python officiel](http://docs.python.org/3/tutorial/)
         * [Full Stack Python](http://www.fullstackpython.com)
         * [Udacity - Apprenez le Python orienté objet](http://www.udacity.com/course/programming-foundations-with-python--ud036)
 


### PR DESCRIPTION
There were a few links to went to the Python tutorial for various different versions. Now the link always goes to the most up-to-date version of Python 3.